### PR TITLE
Add reusable Action for commit message checks

### DIFF
--- a/.github/workflows/test-itself.yaml
+++ b/.github/workflows/test-itself.yaml
@@ -1,0 +1,12 @@
+name: Test this Action by running it against itself
+
+on:
+  pull_request:
+
+jobs:
+  run-itself:
+    runs-on: ubuntu-24.04
+    name: Check its own commit messages
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,26 @@
+name: Commit message standards checks
+description: Check the integrity of commit messages against Space ROS project standards
+
+runs:
+  using: composite
+  steps:
+    - name: Un-shallow the git history so we can poke around in it
+      run: git fetch --unshallow
+      shell: bash
+
+    - name: Check that every commit name includes an issue reference like "#1"
+      run: |
+        set -eo pipefail
+        IFS=$'\n'
+        commits=$(git log --oneline origin/${{github.base_ref}}..origin/${{github.head_ref}})
+        for commit in $commits
+        do
+          if [[ $commit =~ ^.*#[0-9]+.*$ ]];
+          then
+            continue
+          else
+            echo "Found commit with no issue number: $commit"
+            exit 1
+          fi
+        done
+      shell: bash


### PR DESCRIPTION
Closes #1.

This PR creates a "composite action" we can reference in a one-liner in our other repositories like so:

```
- uses: space-ros/check-commit-message-action@main
```

which will automatically fail PRs that do not include an issue number in every commit, and log a message saying which commit is missing an issue number.