### PR TITLE
Grab commit history from PR branch to support forks

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,11 +8,15 @@ runs:
       run: git fetch --unshallow
       shell: bash
 
+    - name: Support forks by grabbing the commit history from the PR branch
+      run: git fetch origin pull/${{ github.event.number }}/head:updated_head_ref
+      shell: bash
+
     - name: Check that every commit name includes an issue reference like "#1"
       run: |
         set -eo pipefail
         IFS=$'\n'
-        commits=$(git log --oneline origin/${{github.base_ref}}..origin/${{github.head_ref}})
+        commits=$(git log --oneline origin/${{github.base_ref}}..updated_head_ref)
         for commit in $commits
         do
           if [[ $commit =~ ^.*#[0-9]+.*$ ]];


### PR DESCRIPTION
Resolves #3.

I guess we could always add the forked remote and fetch history there, too, but maybe this is cleaner? Unfortunately I can't just grab the HEAD of the `GITHUB_REF` because it includes the simulated merge commit, which obviously fails.

Thoughts?

This seems to work fine both from this fork and the primary repo: https://github.com/space-ros/check-commit-message-action/pull/5/checks