### PR TITLE
Fetch history for the PR ref instead of relying on the origin (issue #3)

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -8,11 +8,15 @@ runs:
       run: git fetch --unshallow
       shell: bash
 
+    - name: Support forks by grabbing the commit history from the PR branch
+      run: git fetch origin pull/${{ github.event.number }}/head:updated_head_ref
+      shell: bash
+
     - name: Check that every commit name includes an issue reference like "#1"
       run: |
         set -eo pipefail
         IFS=$'\n'
-        commits=$(git log --oneline origin/${{github.base_ref}}..origin/${{github.head_ref}})
+        commits=$(git log --oneline origin/${{github.base_ref}}..updated_head_ref)
         for commit in $commits
         do
           if [[ $commit =~ ^.*#[0-9]+.*$ ]];


### PR DESCRIPTION
Making sure this isn't borked for not forks (don't know why it would be)